### PR TITLE
Use v 1.8.5 from official image

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "1.16.0"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -3,10 +3,9 @@
 # Declare variables to be passed into your templates.
 cpa:
   image:
-    # Change to official image asa the PR https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/pull/111 is merged and released
-    repository: freddyfroehlich/cpa-dirty
+    repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
     pullPolicy: IfNotPresent
-    tag: latest
+    tag: 1.8.5
 
   extraArgs:
     - --logtostderr=true


### PR DESCRIPTION
After my PR was merged, we can use the official cluster-proportional-autoscaler docker image instead of freddyfroehlich/cpa-dirty