### PR TITLE
Update CronJob API version

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.16.0"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
@@ -6,7 +6,7 @@
 {{- $failedJobsHistoryLimit := .Values.cronJob.failedJobsHistoryLimit -}}
 {{- $successfulJobsHistoryLimit := .Values.cronJob.successfulJobsHistoryLimit -}}
 {{- range $schedule := .Values.schedules }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cronjob-cas-{{- $schedule.name }}


### PR DESCRIPTION
The currently used API version for the CronJob is deprecated because it moved to `v1`. Therefore we need to update it.