### PR TITLE
Set the priorityClassName, topologySpreadConstraints in op-deployment

### DIFF
--- a/charts/cluster-overprovisioner/README.md
+++ b/charts/cluster-overprovisioner/README.md
@@ -110,7 +110,8 @@ For every schedule a cronjob is created, that replaces the active config with th
 | op.serviceAccount.annotations | object | `{}` | Mount ServiceAccount-Token (true, because cpa accesses kube-api)|
 | op.serviceAccount.automountServiceAccountToken | bool | `false` | Annotations to add to the service account |
 | op.serviceAccount.name | string | `""` | Name of the Service Account to use  |
-| op.tolerations | list | `[]` | Tolerations of the cpa Pod |
+| op.tolerations | list | `[]` | Tolerations of the op Pod |
+| op.topologySpreadConstraints | list | `[]` | topologySpreadConstraints of the op Pod |
 | cronJob.failedJobsHistoryLimit | int | `1` | Specifies, how many failed Jobs should be kept |
 | cronJob.image.pullPolicy | string | `"Always"` | ImagePullPolicy |
 | cronJob.image.repository | string | `"ghcr.io/codecentric/cluster-overprovisioner-helper"` | Image used to executed the cronjob |

--- a/charts/cluster-overprovisioner/templates/op-deployment.yaml
+++ b/charts/cluster-overprovisioner/templates/op-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         {{- include "cluster-overprovisioner.op.selectorLabels" . | nindent 8 }}
     spec:
+      priorityClassName: {{ .Values.op.priorityClasses.overprovision.name }}
       {{- with .Values.op.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -44,6 +45,10 @@ spec:
       {{- end }}
       {{- with .Values.op.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.op.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -122,6 +122,8 @@ op:
 
   affinity: {}
 
+  topologySpreadConstraints: []
+
   priorityClasses:
     default:
       enabled: false


### PR DESCRIPTION
op deployment wasn't actually using the overprovisioning priorityclass

Also added ability to set the topologySpreadConstraints while I was here.

Fixed a paste-o that I noticed in the readme while I was adding the new field.