### PR TITLE
fix: PriorityClass and TopologySpreadConstraints

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.16.0"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/README.md
+++ b/charts/cluster-overprovisioner/README.md
@@ -111,6 +111,7 @@ For every schedule a cronjob is created, that replaces the active config with th
 | op.serviceAccount.automountServiceAccountToken | bool | `false` | Annotations to add to the service account |
 | op.serviceAccount.name | string | `""` | Name of the Service Account to use  |
 | op.tolerations | list | `[]` | Tolerations of the cpa Pod |
+| op.topologySpreadConstraints | list | `[]` | topologySpreadConstraints of the op Pod |
 | cronJob.failedJobsHistoryLimit | int | `1` | Specifies, how many failed Jobs should be kept |
 | cronJob.image.pullPolicy | string | `"Always"` | ImagePullPolicy |
 | cronJob.image.repository | string | `"ghcr.io/codecentric/cluster-overprovisioner-helper"` | Image used to executed the cronjob |

--- a/charts/cluster-overprovisioner/templates/op-deployment.yaml
+++ b/charts/cluster-overprovisioner/templates/op-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         {{- include "cluster-overprovisioner.op.selectorLabels" . | nindent 8 }}
     spec:
+      priorityClassName: {{ .Values.op.priorityClasses.overprovision.name }}
       {{- with .Values.op.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -44,6 +45,10 @@ spec:
       {{- end }}
       {{- with .Values.op.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.op.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -122,6 +122,8 @@ op:
 
   affinity: {}
 
+  topologySpreadConstraints: []
+
   priorityClasses:
     default:
       enabled: false


### PR DESCRIPTION
**Description:**
Add priorityClass to `op` Deployment manifest
Add topologySpreadConstraints field to `op` Deployment manifest

**Kudos:**
Joe Hohertz (@jhohertz)