### PR TITLE
fix: Adapt for GitOps tools

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "1.16.0"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/templates/op-deployment.yaml
+++ b/charts/cluster-overprovisioner/templates/op-deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "cluster-overprovisioner.op.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if .Values.op.replicas }}
+  replicas: {{ .Values.op.replicas | int }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cluster-overprovisioner.op.selectorLabels" . | nindent 6 }}

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -74,6 +74,8 @@ op:
     pullPolicy: IfNotPresent
     tag: 3.2
 
+  replicas: null
+
   imagePullSecrets: []
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
**Description:**
Gitops tools like ArgoCD does not allow CPA to autoscale the OP pod due to it is always resyncing and rewriting the replicas parameter on the deployment. 

This PR fixes that deleting replicas field from the deployment, but allowing setting a number for those cases where Gitops is not using