### PR TITLE
update conjob apiversion for supported k8s versions

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: "1.16.0"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
@@ -6,7 +6,7 @@
 {{- $failedJobsHistoryLimit := .Values.cronJob.failedJobsHistoryLimit -}}
 {{- $successfulJobsHistoryLimit := .Values.cronJob.successfulJobsHistoryLimit -}}
 {{- range $schedule := .Values.schedules }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: cronjob-cas-{{- $schedule.name }}


### PR DESCRIPTION
CronJob has been available as batch/v1 since 1.21 (April 2021). 1.25 (Aug 2022) stopped serving CronJob as batch/v1beta1 and the chart no longer works with 1.25 and newer versions