### PR TITLE
fix cronjob bug

### DIFF
--- a/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
@@ -5,6 +5,7 @@
 {{- $pullPolicy := .Values.cronJob.image.pullPolicy -}}
 {{- $failedJobsHistoryLimit := .Values.cronJob.failedJobsHistoryLimit -}}
 {{- $successfulJobsHistoryLimit := .Values.cronJob.successfulJobsHistoryLimit -}}
+{{- $global := . }}
 {{- range $schedule := .Values.schedules }}
 apiVersion: batch/v1
 kind: CronJob
@@ -37,6 +38,14 @@ spec:
               - name: tmp
                 mountPath: /tmp/
           restartPolicy: Never
+          {{- with $global.Values.cpa.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $global.Values.cpa.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumes:
             - name: script
               configMap:


### PR DESCRIPTION
In environments that have implemented taints and tolerations, it is crucial to define tolerations for cronjobs as well; otherwise, the spiked pods will remain in a "pending" status.