### PR TITLE
Add timeZone as param to CronJob

### DIFF
--- a/charts/cluster-overprovisioner/templates/cpa-configmap.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-configmap.yaml
@@ -14,7 +14,7 @@ data:
   {{- end }}
 ---
 {{- $labels := include "cluster-overprovisioner.cpa.labels" . -}}
-{{- $namespace := .Values.Namespace -}}
+{{- $namespace := .Release.Namespace -}}
 {{- range $schedule := .Values.schedules }}
 {{- if ne (len $schedule.config) 1 }}
 {{ fail (printf "%s%s." "You need to specify exactly one config for schedule " $schedule.name) }}
@@ -32,7 +32,7 @@ data:
 ---
 {{- end }}
 {{- $labels := include "cluster-overprovisioner.labels" . -}}
-{{- $namespace := .Values.Namespace -}}
+{{- $namespace := .Release.Namespace -}}
 {{- range $schedule := .Values.schedules }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-cronjob.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   failedJobsHistoryLimit: {{ $failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ $successfulJobsHistoryLimit }}
+  timeZone: {{ $schedule.timeZone }}
   schedule: {{ $schedule.cronTimeExpression | quote }}
   jobTemplate:
     spec:

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -159,6 +159,7 @@ defaultConfig:
 # Example of a schedule:
 # - name: night
 #  cronTimeExpression: "0 16 * * 1-5"  # disable overprovisioning Monday - Friday from 6pm
+#  timeZone: America/New_York # https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 #  config:
 #    ladder:
 #      {


### PR DESCRIPTION
Without this, the timeZone of the CronJob is whatever your scheduler's local time is.

It also fixes the namespace references in the cronjob configmaps