### PR TITLE
feat: patch cas-schedule-active configmap instead of replacing

### DIFF
--- a/charts/cluster-overprovisioner/Chart.yaml
+++ b/charts/cluster-overprovisioner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cluster-overprovisioner
 description: Helm chart, that enables scheduled scaling of a target resource, intended to be add overprovisioning to an autoscaling k8s cluster.
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "1.8.9"
 keywords:
   - cluster-autoscaler

--- a/charts/cluster-overprovisioner/templates/cpa-configmap.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   {{- range $key,$value := $.Values.defaultConfig }}
   {{ $key }}: |-
-    {{ $value | mustToJson }} 
+    {{ $value | mustToJson }}
   {{- end }}
 ---
 {{- $labels := include "cluster-overprovisioner.cpa.labels" . -}}
@@ -27,7 +27,7 @@ metadata:
 data:
   {{- range $key,$value := $schedule.config }}
   {{ $key }}: |-
-    {{ $value | mustToJson }} 
+    {{ $value | mustToJson }}
   {{- end }}
 ---
 {{- end }}
@@ -42,17 +42,16 @@ metadata:
     {{ $labels | nindent 4 }}
 data:
   configmap.sh: |
-    #!/usr/bin/env sh
+    #!/usr/bin/env bash
 
-    # This script replaces the currently active configmap with another available one.
-
+    # This script patches cas-schedule-active configmap with specific schedule config.
     set -o errexit
     set -o nounset
     set -o pipefail
 
     main() {
-
-        kubectl get cm "cas-schedule-{{- $schedule.name }}" -n "{{ $namespace }}" -o yaml | yq e '.metadata.name = "cas-schedule-active"' - | kubectl replace --force -f -
+        source_data=$(kubectl get cm "cas-schedule-{{- $schedule.name }}" -n "{{ $namespace }}" -o json | jq -r '.data')
+        kubectl get cm "cas-schedule-active" -n "{{ $namespace }}" -o json | jq --argjson data "$source_data" '.data = $data' | kubectl apply -f -
     }
 
     main "$@"

--- a/charts/cluster-overprovisioner/templates/cpa-rbac.yaml
+++ b/charts/cluster-overprovisioner/templates/cpa-rbac.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "cluster-overprovisioner.cpa.fullname" . }}
   labels:
-    {{- include "cluster-overprovisioner.cpa.labels" . | nindent 4 }} 
+    {{- include "cluster-overprovisioner.cpa.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -22,7 +22,7 @@ metadata:
   name: {{ include "cluster-overprovisioner.cpa.fullname" . }}
   namespace: {{ include "cluster-overprovisioner.cpa.target.namespace" . }}
   labels:
-    {{- include "cluster-overprovisioner.cpa.labels" . | nindent 4 }} 
+    {{- include "cluster-overprovisioner.cpa.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
@@ -32,7 +32,7 @@ rules:
     verbs: ["get", "update"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "create", "update", "delete"]
+    verbs: ["get", "create", "update", "delete", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/cluster-overprovisioner/values.yaml
+++ b/charts/cluster-overprovisioner/values.yaml
@@ -72,7 +72,7 @@ op:
   image:
     repository: k8s.gcr.io/pause
     pullPolicy: IfNotPresent
-    tag: 3.2
+    tag: 3.9
 
   replicas: null
 
@@ -138,9 +138,9 @@ op:
 
 cronJob:
   image:
-    repository: ghcr.io/codecentric/cluster-overprovisioner-helper
-    pullPolicy: Always
-    tag: latest
+    repository: bitnami/kubectl
+    pullPolicy: IfNotPresent
+    tag: 1.30
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 1
 


### PR DESCRIPTION
Hello!

I got a problem with current version, which force replaces cas-schedule-active configmap, cause I've deployed chart using argo cd. While configmap changes are configured to be ignored by argocd, force replacing (delete/create) forces argocd to sync originally deployed configmap, which overrides the configmap cronjob wants to create.

I got this script working fine with `bitnami/kubectl:1.30` image, **jq is missing from** `ghcr.io/codecentric/cluster-overprovisioner-helper:latest`

`yq` in `ghcr.io/codecentric/cluster-overprovisioner-helper:latest` is acting weird giving me error for some reason, didn't bothered to investigate why, but this should do the same with yq, at least that works locally:
```
kubectl get cm "cas-schedule-{{- $schedule.name }}" -n "{{ $namespace }}" -o yaml | yq e '.data' - > /tmp/source_data.yaml
kubectl get cm "cas-schedule-active" -n "{{ $namespace }}" -o yaml | yq e '.data = load("/tmp/source_data.yaml")' - | kubectl apply -f -
```

Thanks!